### PR TITLE
add quiet flag for ssh-add

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -105,7 +105,7 @@ load-our-ssh-keys() {
       # the macOS keychain
       
       # Load all ssh keys that have pass phrases stored in macOS keychain
-      ssh-add -A
+      ssh-add -qA
     fi
 
     for key in $(find ~/.ssh -type f -a \( -name '*id_rsa' -o -name '*id_dsa' -o -name '*id_ecdsa' \))


### PR DESCRIPTION
After using the flag to prevent SSH keys from listing on shell startup I was still finding that the SSH identities are printed out. Using the `-q` flag tells ssh-add to prints no output on successful operations.